### PR TITLE
Implement forecasting functionality

### DIFF
--- a/include/forecast.hpp
+++ b/include/forecast.hpp
@@ -1,19 +1,17 @@
-#ifndef DATA_CLEANER_HPP
-#define DATA_CLEANER_HPP
 
-#include <map>
-#include <string>
+#ifndef FORECAST_HPP
+#define FORECAST_HPP
 
-struct RowData {
-    double icsa = std::numeric_limits<double>::quiet_NaN();
-    double unrate = std::numeric_limits<double>::quiet_NaN();
-    double jtsjol = std::numeric_limits<double>::quiet_NaN();
-};
+#include <vector>
 
-std::map<std::string, RowData> merge_data(const std::string& icsaPath,
-                                          const std::string& unratePath,
-                                          const std::string& jtsjolPath,
-                                          const std::string& startDate,
-                                          const std::string& endDate);
+// Simple moving average forecast
+std::vector<double> forecast_sma(const std::vector<double>& series,
+                                 std::size_t window,
+                                 std::size_t steps);
+
+// Simple exponential smoothing forecast
+std::vector<double> forecast_exp(const std::vector<double>& series,
+                                 double alpha,
+                                 std::size_t steps);
 
 #endif

--- a/src/forecast.cpp
+++ b/src/forecast.cpp
@@ -5,13 +5,36 @@
 std::vector<double> forecast_sma(const std::vector<double>& series,
                                  std::size_t window,
                                  std::size_t steps) {
-    // TODO: implement SMA forecast
-    return {};
+    std::vector<double> forecasts;
+    if (window == 0 || series.size() < window) return forecasts;
+
+    std::vector<double> extended(series.begin(), series.end());
+    forecasts.reserve(steps);
+
+    for (std::size_t i = 0; i < steps; ++i) {
+        double sum = 0.0;
+        for (std::size_t j = extended.size() - window; j < extended.size(); ++j) {
+            sum += extended[j];
+        }
+        double val = sum / static_cast<double>(window);
+        forecasts.push_back(val);
+        extended.push_back(val);
+    }
+
+    return forecasts;
 }
 
 std::vector<double> forecast_exp(const std::vector<double>& series,
                                  double alpha,
                                  std::size_t steps) {
-    // TODO: implement EXP forecast
-    return {};
+    std::vector<double> forecasts;
+    if (series.empty()) return forecasts;
+
+    double s = series.front();
+    for (std::size_t i = 1; i < series.size(); ++i) {
+        s = alpha * series[i] + (1.0 - alpha) * s;
+    }
+
+    forecasts.assign(steps, s);
+    return forecasts;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,10 +3,37 @@
 #include "forecast.hpp"
 #include "plot.hpp"
 #include "utils.hpp"
+#include <chrono>
+#include <vector>
 
 int main() {
     auto table = merge_data("data/ICSA.csv", "data/UNRATE.csv", "data/JTSJOL.csv",
                            "2020-01-01", "2025-06-01");
     std::cout << "Merged " << table.size() << " rows to data/weekly_data.csv\n";
+
+    std::vector<double> icsaVec;
+    icsaVec.reserve(table.size());
+    for (const auto& [date, row] : table) {
+        icsaVec.push_back(row.icsa);
+    }
+
+    auto start = std::chrono::high_resolution_clock::now();
+    auto smaPred = forecast_sma(icsaVec, 4, 3);
+    auto end = std::chrono::high_resolution_clock::now();
+    auto smaTime = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+
+    start = std::chrono::high_resolution_clock::now();
+    auto expPred = forecast_exp(icsaVec, 0.2, 3);
+    end = std::chrono::high_resolution_clock::now();
+    auto expTime = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+
+    std::cout << "SMA forecast (" << smaTime << " us): ";
+    for (double v : smaPred) std::cout << v << ' ';
+    std::cout << "\n";
+
+    std::cout << "EXP forecast (" << expTime << " us): ";
+    for (double v : expPred) std::cout << v << ' ';
+    std::cout << "\n";
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- add forecast API declarations
- implement moving average and exponential smoothing forecasts
- demonstrate forecasting in `main.cpp`

## Testing
- `g++ -std=c++17 src/main.cpp src/data_cleaner.cpp src/forecast.cpp src/utils.cpp -Iinclude -o forecast_app`
- `./forecast_app | head`

------
https://chatgpt.com/codex/tasks/task_e_6848342381988333bb8db30aedbcbc63