### PR TITLE
Add ASCII sparkline implementation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,10 @@ int main() {
                 smaPred,
                 "output/icsa.png");
 
-    ascii_sparkline("ICSA Weekly Claims Trend", icsaTrend);
+    ascii_sparkline("ICSA Raw Values", icsaVec);
+    ascii_sparkline("ICSA Trend (window=4)", icsaTrend);
+    ascii_sparkline("SMA Forecast (3 weeks)", smaPred);
+    ascii_sparkline("EXP Forecast (3 weeks)", expPred);
 
     return 0;
 }

--- a/src/plot.cpp
+++ b/src/plot.cpp
@@ -39,21 +39,26 @@ void plot_series(const std::string& title,
 
 void ascii_sparkline(const std::string& title,
                      const std::vector<double>& data) {
-    static const char* blocks = "▁▂▃▄▅▆▇█";
+    static const char* blocks[] = {"▁","▂","▃","▄","▅","▆","▇","█"};
+
     if (data.empty()) {
+        std::cout << "No data for " << title << std::endl;
         return;
     }
 
     double minVal = *std::min_element(data.begin(), data.end());
     double maxVal = *std::max_element(data.begin(), data.end());
-    double range = maxVal - minVal;
-    if (range == 0) range = 1.0;
 
-    std::cout << title << "\n";
+    std::cout << title << '\n';
+    std::string line;
     for (double v : data) {
-        int idx = static_cast<int>(std::round((v - minVal) / range * 7));
-        idx = std::clamp(idx, 0, 7);
-        std::cout << blocks[idx];
+        double norm = 0.0;
+        if (maxVal > minVal) {
+            norm = (v - minVal) / (maxVal - minVal);
+        }
+        int bin = static_cast<int>(std::floor(norm * 7.0 + 0.5));
+        bin = std::clamp(bin, 0, 7);
+        line += blocks[bin];
     }
-    std::cout << std::endl;
+    std::cout << line << std::endl;
 }


### PR DESCRIPTION
## Summary
- implement ascii_sparkline to print normalized unicode blocks
- show sparklines for raw data, trend, and forecasts

## Testing
- `cmake --build build2` *(fails: 'figure_size' is not a member of 'plt')*

------
https://chatgpt.com/codex/tasks/task_e_684839415f248333a024f549a2e51866