### PR TITLE
Embed Python runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ From the `build/` directory run:
 ```
 
 The program writes forecast data to `output/forecast.csv` and generates PNG plots in the `output/` folder.
+
+## Bundled Python Runtime
+
+The application embeds the Python interpreter to produce plots via
+Matplotlib. To run on a system without Python installed, place a
+minimal Python distribution in a `python/` folder next to the
+executable. `src/main.cpp` sets `PYTHONHOME` to this directory before
+initializing the interpreter.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,8 +9,12 @@
 #include <iomanip>
 #include <chrono>
 #include <vector>
+#include <Python.h>
 
 int main() {
+    Py_SetProgramName(L"EconomicForecasting");
+    Py_SetPythonHome(L"./python");
+
     auto table = merge_data("data/ICSA.csv", "data/UNRATE.csv", "data/JTSJOL.csv",
                            "2020-01-01", "2025-06-01");
     std::cout << "Merged " << table.size() << " rows to data/weekly_data.csv\n";


### PR DESCRIPTION
## Summary
- set `PYTHONHOME` from main to support a bundled Python runtime
- document how to package the Python interpreter

## Testing
- `cmake ..`
- `cmake --build .`

------
https://chatgpt.com/codex/tasks/task_e_68484a81f12c833391993fa16e653090