### PR TITLE
Add Python stdlib and NumPy to package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,21 @@ add_executable(EconomicForecasting
 )
 
 target_link_libraries(EconomicForecasting PRIVATE ${Python3_LIBRARIES})
+
+# Bundle minimal Python runtime after build
+set(PY_BUNDLE_DIR "${CMAKE_CURRENT_BINARY_DIR}/python")
+# Determine the site-packages directory at configure time
+execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "import sysconfig,sys;sys.stdout.write(sysconfig.get_path('purelib'))"
+    OUTPUT_VARIABLE PY_SITE
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+add_custom_command(TARGET EconomicForecasting POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${PY_BUNDLE_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${Python3_STDLIB}"
+            "${PY_BUNDLE_DIR}/Lib"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${PY_SITE}"
+            "${PY_BUNDLE_DIR}/Lib/site-packages"
+    COMMENT "Copy Python standard library and site-packages")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,10 +10,36 @@
 #include <chrono>
 #include <vector>
 #include <Python.h>
+#include <filesystem>
 
 int main() {
+    std::filesystem::path pyHome = "./python";
+    std::filesystem::path encPath = pyHome / "Lib" / "encodings";
+    if(!std::filesystem::exists(encPath)) {
+        std::cerr << "Missing Python encodings directory: " << encPath << '\n';
+        return 1;
+    }
+
+    std::filesystem::path numpyPath = pyHome / "Lib" / "site-packages" / "numpy";
+    if(!std::filesystem::exists(numpyPath)) {
+        std::cerr << "Missing NumPy package: " << numpyPath << '\n';
+        return 1;
+    }
+
+    std::wstring pyHomeW = L"./python";
+#ifdef _WIN32
+    std::wstring pyPath = pyHomeW + L";" + pyHomeW + L"/Lib;" + pyHomeW + L"/DLLs";
+#else
+    std::wstring pyPath = pyHomeW + L":" + pyHomeW + L"/Lib";
+#endif
+
     Py_SetProgramName(L"EconomicForecasting");
-    Py_SetPythonHome(L"./python");
+    Py_SetPythonHome(pyHomeW.c_str());
+    Py_SetPath(pyPath.c_str());
+
+    if(pyPath.find(L"/Lib") == std::wstring::npos) {
+        std::wcerr << L"Warning: python Lib directory not on path" << std::endl;
+    }
 
     auto table = merge_data("data/ICSA.csv", "data/UNRATE.csv", "data/JTSJOL.csv",
                            "2020-01-01", "2025-06-01");


### PR DESCRIPTION
## Summary
- bundle Python site-packages alongside standard library for embedding
- verify that bundled NumPy exists before initializing the interpreter

## Testing
- `cmake .. && cmake --build . -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684852c041408333be89f567716dca27