### PR TITLE
Fix Python path for embedded runtime

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ int main() {
 #ifdef _WIN32
     std::wstring pyPath = pyHomeW + L";" + pyHomeW + L"/Lib;" + pyHomeW + L"/DLLs";
 #else
-    std::wstring pyPath = pyHomeW + L":" + pyHomeW + L"/Lib";
+    std::wstring pyPath = pyHomeW + L":" + pyHomeW + L"/Lib:" + pyHomeW + L"/Lib/site-packages:" + pyHomeW + L"/Lib/lib-dynload";
 #endif
 
     Py_SetProgramName(L"EconomicForecasting");


### PR DESCRIPTION
## Summary
- ensure site-packages and lib-dynload are on embedded Python path

## Testing
- `cmake ..`
- `cmake --build . --config Release`
- `./EconomicForecasting`

------
https://chatgpt.com/codex/tasks/task_e_6848604ba404833389f0af260ba5c037