### PR TITLE
Add data path prompt for CSV files

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,21 @@ int main() {
         std::wcerr << L"Warning: python Lib directory not on path" << std::endl;
     }
 
-    auto table = merge_data("data/ICSA.csv", "data/UNRATE.csv", "data/JTSJOL.csv",
+    std::string dataInput;
+    std::cout << "Enter path to directory containing ICSA.csv, UNRATE.csv and JTSJOL.csv [data]: ";
+    std::getline(std::cin, dataInput);
+    if(dataInput.empty()) dataInput = "data";
+    std::filesystem::path dataDir = dataInput;
+    if(!std::filesystem::exists(dataDir / "ICSA.csv") ||
+       !std::filesystem::exists(dataDir / "UNRATE.csv") ||
+       !std::filesystem::exists(dataDir / "JTSJOL.csv")) {
+        std::cerr << "Cannot locate required CSV files in " << dataDir << '\n';
+        return 1;
+    }
+
+    auto table = merge_data((dataDir / "ICSA.csv").string(),
+                           (dataDir / "UNRATE.csv").string(),
+                           (dataDir / "JTSJOL.csv").string(),
                            "2020-01-01", "2025-06-01");
     std::cout << "Merged " << table.size() << " rows to data/weekly_data.csv\n";
 


### PR DESCRIPTION
## Summary
- ask user to provide directory containing CSV input files
- use that directory when loading ICSA, UNRATE, JTSJOL data

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./EconomicForecasting` with prompt


------
https://chatgpt.com/codex/tasks/task_e_68486541c1cc8333b1f30c336965780e