### PR TITLE
Embed python runtime and matplotlib in installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,3 +40,8 @@ add_custom_command(TARGET EconomicForecasting POST_BUILD
             "${PY_SITE}"
             "${PY_BUNDLE_DIR}/Lib/site-packages"
     COMMENT "Copy Python standard library and site-packages")
+
+# Install executable and bundled Python runtime
+install(TARGETS EconomicForecasting DESTINATION .)
+install(DIRECTORY "${PY_BUNDLE_DIR}/Lib" DESTINATION python)
+

--- a/include/matplotlibcpp.h
+++ b/include/matplotlibcpp.h
@@ -10,9 +10,11 @@ namespace matplotlibcpp {
 namespace detail {
 inline void ensure_interpreter() {
     static bool initialized = false;
-    if (!initialized) {
+    if (!Py_IsInitialized()) {
         Py_Initialize();
-        PyRun_SimpleString("import matplotlib; matplotlib.use('Agg'); import matplotlib.pyplot as plt");
+    }
+    if (!initialized) {
+        PyRun_SimpleString("import matplotlib.pyplot as plt");
         initialized = true;
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,11 @@ int main() {
     Py_SetPythonHome(pyHomeW.c_str());
     Py_SetPath(pyPath.c_str());
 
+    Py_Initialize();
+    if (PyRun_SimpleString("import matplotlib") != 0) {
+        std::cerr << "Failed to import matplotlib" << std::endl;
+    }
+
     if(pyPath.find(L"/Lib") == std::wstring::npos) {
         std::wcerr << L"Warning: python Lib directory not on path" << std::endl;
     }
@@ -143,5 +148,6 @@ int main() {
     ascii_sparkline("SMA Forecast (3 weeks)", smaPred);
     ascii_sparkline("EXP Forecast (3 weeks)", expPred);
 
+    Py_Finalize();
     return 0;
 }


### PR DESCRIPTION
## Summary
- copy Python standard library and site-packages during install
- set `PYTHONHOME` before `Py_Initialize` and check for matplotlib
- ensure matplotlibcpp initialises with `import matplotlib.pyplot as plt`

## Testing
- `cmake ..`
- `cmake --build .`
- `./EconomicForecasting < /dev/null` *(fails: cannot locate data)*
- `cp -r ../data . && ./EconomicForecasting < /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_684866a5c998833389c6269eabe4d037