### PR TITLE
Embed static Python runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,18 @@ project(EconomicForecasting LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Python / NumPy (for matplotlib-cpp)
-find_package(Python3 COMPONENTS Interpreter Development NumPy REQUIRED)
+# Location of the static Python distribution
+set(PYTHON_ROOT "C:/Python39" CACHE PATH "Python 3.9 root containing static build")
+
+# Find the static python39.lib
+find_library(PYTHON39_LIB
+    NAMES python39
+    PATHS "${PYTHON_ROOT}/static"
+    NO_DEFAULT_PATH
+    REQUIRED)
 
 # Include directories
-include_directories(include)
-include_directories(${Python3_INCLUDE_DIRS} ${Python3_NumPy_INCLUDE_DIRS})
+include_directories(include "${PYTHON_ROOT}/include")
 
 # Source files
 add_executable(EconomicForecasting
@@ -21,20 +27,17 @@ add_executable(EconomicForecasting
     src/utils.cpp
 )
 
-target_link_libraries(EconomicForecasting PRIVATE ${Python3_LIBRARIES})
+target_link_libraries(EconomicForecasting PRIVATE ${PYTHON39_LIB})
 
 # Bundle minimal Python runtime after build
 set(PY_BUNDLE_DIR "${CMAKE_CURRENT_BINARY_DIR}/python")
-# Determine the site-packages directory at configure time
-execute_process(
-    COMMAND ${Python3_EXECUTABLE} -c "import sysconfig,sys;sys.stdout.write(sysconfig.get_path('purelib'))"
-    OUTPUT_VARIABLE PY_SITE
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(PYTHON_STDLIB "${PYTHON_ROOT}/Lib")
+set(PY_SITE "${PYTHON_STDLIB}/site-packages")
 
 add_custom_command(TARGET EconomicForecasting POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory "${PY_BUNDLE_DIR}"
     COMMAND ${CMAKE_COMMAND} -E copy_directory
-            "${Python3_STDLIB}"
+            "${PYTHON_STDLIB}"
             "${PY_BUNDLE_DIR}/Lib"
     COMMAND ${CMAKE_COMMAND} -E copy_directory
             "${PY_SITE}"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,8 +38,14 @@ int main() {
     Py_SetPath(pyPath.c_str());
 
     Py_Initialize();
-    if (PyRun_SimpleString("import matplotlib") != 0) {
-        std::cerr << "Failed to import matplotlib" << std::endl;
+    // Verify that the embedded interpreter can import matplotlib and create a figure
+    int rc = PyRun_SimpleString(
+        "import matplotlib; import matplotlib.pyplot as plt;"
+        "plt.plot([0,1],[0,1]);"
+        "plt.savefig('output/embed_test.png')"
+    );
+    if (rc != 0) {
+        std::cerr << "Failed Python embedding test" << std::endl;
     }
 
     if(pyPath.find(L"/Lib") == std::wstring::npos) {


### PR DESCRIPTION
## Summary
- link against a local static `python39.lib`
- copy the specified Python `Lib/` and `site-packages` directories next to the executable
- initialize Python using `Py_SetPythonHome` and run a simple matplotlib test

## Testing
- `cmake -S . -B build` *(fails: Could not find PYTHON39_LIB)*

------
https://chatgpt.com/codex/tasks/task_e_684869b0af208333953caf1ccb59622a