### PR TITLE
Fix Python initialization by removing Py_SetProgramName

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,6 @@
 #include <filesystem>
 
 int main() {
-    Py_SetProgramName(L"EconomicForecasting");
     Py_Initialize();
 
     bool has_numpy = (PyRun_SimpleString("import numpy") == 0);


### PR DESCRIPTION
## Summary
- fix embedded Python initialization by not overriding program name

## Testing
- `cmake --build build --config Release`
- `./EconomicForecasting <<< 'y' | head`

------
https://chatgpt.com/codex/tasks/task_e_684896047e6083338c264598cb1d0e7d